### PR TITLE
changed pagination to 11 video cards

### DIFF
--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -79,7 +79,7 @@ export default function Main() {
               )}{" "}
               <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 3xl:grid-cols-5 gap-6 justify-items-center place-items-center align-middle w-full auto-rows-max p-6">
                 {getVideosByTopic(videoData, topic.name)
-                  .slice(0, 15)
+                  .slice(0, 11)
                   .map((video) => (
                     <VideoCard
                       video={video}


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request modifies the pagination in the main component to display 11 video cards instead of 15, enhancing the user interface by adjusting the number of video cards shown per page.

- **Enhancements**:
    - Changed the pagination to display 11 video cards instead of 15 in the main component.

<!-- Generated by sourcery-ai[bot]: end summary -->