### PR TITLE
fix by removing quotes around authorization in header

### DIFF
--- a/src/data/videoData.tsx
+++ b/src/data/videoData.tsx
@@ -106,11 +106,12 @@ export async function toggleLike(id: Video["id"]): Promise<Response> {
 }
 
 export const getVideoByVideoId = async (videoId: string, authToken: string | null): Promise<Video> => {
+  console.log("is this authToken null?", authToken === null);
   const response = await fetch(`https://www.mytorahtoday.com/api/videos/${videoId}/`, {
     cache: "no-store",
     headers: {
       "Content-Type": "application/json",
-      ...(authToken && { "Authorization": `${authToken}` }),
+      ...(authToken && { Authorization: `${authToken}` }),
     },
   });
   const data = await response.json();


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the authorization header in the getVideoByVideoId function by removing quotes around the Authorization key to ensure proper header formatting.

Bug Fixes:
- Fix the authorization header by removing quotes around the Authorization key.

<!-- Generated by sourcery-ai[bot]: end summary -->