### PR TITLE
possibly fixed by changing fetch slightly

### DIFF
--- a/src/app/topics/[topic]/[subtopic]/[video_id]/page.tsx
+++ b/src/app/topics/[topic]/[subtopic]/[video_id]/page.tsx
@@ -27,9 +27,10 @@ export default async function VideoPage({ params }: Props) {
     const response = await fetch(
       `https://www.mytorahtoday.com/api/videos/${video_id}/`,
       {
+        method: "GET",
         headers: {
           "Content-Type": "application/json",
-          ...(authToken && { Authorization: `${authToken}` }),
+          ...(authToken && { "Authorization": `Token ${authToken}` }),
         },
         cache: "no-store",
       }


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the authorization header in the fetch request by adding the 'Token' prefix to the authToken, ensuring proper authentication.

Bug Fixes:
- Correct the authorization header format in the fetch request to use 'Token' prefix for the authToken.

<!-- Generated by sourcery-ai[bot]: end summary -->