### PR TITLE
build fail fix: removed wrong {auth} export from next-auth route

### DIFF
--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -84,4 +84,3 @@ const { handlers, auth } = NextAuth({
 
 export const { GET } = handlers;
 export const { POST } = handlers;
-export { auth };


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix build failure by removing the incorrect export of 'auth' from the next-auth route.

Bug Fixes:
- Remove incorrect export of 'auth' from the next-auth route to fix build failure.

<!-- Generated by sourcery-ai[bot]: end summary -->