### PR TITLE
removed 'export' from RelatedvideoSection as it failed build

### DIFF
--- a/src/app/topics/[topic]/[subtopic]/[video_id]/page.tsx
+++ b/src/app/topics/[topic]/[subtopic]/[video_id]/page.tsx
@@ -125,7 +125,7 @@ export default async function VideoPage({ params }: Props) {
   }
 }
 
-export async function RelatedVideosSection({
+async function RelatedVideosSection({
   topic,
   subtopic,
   authToken,


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix a build failure by removing the 'export' keyword from the RelatedVideosSection function.

Build:
- Remove 'export' keyword from the RelatedVideosSection function to fix a build failure.

<!-- Generated by sourcery-ai[bot]: end summary -->